### PR TITLE
Inject setuptools

### DIFF
--- a/ansible-utils/ubuntu-gh-runner.sh
+++ b/ansible-utils/ubuntu-gh-runner.sh
@@ -63,7 +63,7 @@ sudo rm -rf $(echo "/opt/pipx/venvs/ansible-core/lib/python3.1"*"/site-packages/
 sudo rm -rf $(echo "/opt/pipx/venvs/ansible-core/lib/python3.1"*"/site-packages/ansible_collections/ansible/windows") # Delete existing windows collection
 sudo su - action-runner -c "ansible-galaxy collection install ansible.windows:==2.4.0 azure.azcollection:==2.3.0" # Pin older collection versions
 sudo su - action-runner -c "cat /opt/runner-cache/.ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt | sed -e 's/#.*//' | xargs pipx inject ansible-core"
-sudo su - action-runner -c "pipx inject ansible-core pywinrm jmespath pygithub"
+sudo su - action-runner -c "pipx inject ansible-core pywinrm jmespath pygithub setuptools"
 pip install PyGithub
 
 ./svc.sh install action-runner


### PR DESCRIPTION
Injects setuptools into the ansible-core pipx venv, this is required to run sql forwarding playbook on the updated runner image.

Resolves an issue where sql forwarding playbook is unable to run due to setuptools no longer being available by default in virtual environments created with venv.

https://github.com/mu-editor/mu/issues/2485

https://github.com/tecgovtnz/layer-2/actions/runs/13230681032/job/36927329004
<img width="529" alt="image" src="https://github.com/user-attachments/assets/34bb3b42-c168-4775-848e-bf7ff6d86756" />
