### PR TITLE
Add hostname label

### DIFF
--- a/ansible-utils/ubuntu-gh-runner.sh
+++ b/ansible-utils/ubuntu-gh-runner.sh
@@ -44,7 +44,7 @@ else
     RUNNER_NAME=$(hostname)
 fi
 
- ./config.sh --url https://github.com/tecgovtnz --token $TOKEN --runasservice --name $RUNNER_NAME --work _work --runnergroup $ENVIRONMENT --labels $ENVIRONMENT
+ ./config.sh --url https://github.com/tecgovtnz --token $TOKEN --runasservice --name $RUNNER_NAME --work _work --runnergroup $ENVIRONMENT --labels $ENVIRONMENT $HOSTNAME
 # install as a service account
 
 


### PR DESCRIPTION
Adds hostname as a label to the runners, this is currently already in prod (manually added).

This was requested by Andrew Polland as it allows him to target specific runners when running cleanup jobs, this should help prevent DXS workflows from filling up root.