### PR TITLE
Runner hostname label fix

### DIFF
--- a/ansible-utils/ubuntu-gh-runner.sh
+++ b/ansible-utils/ubuntu-gh-runner.sh
@@ -44,7 +44,7 @@ else
     RUNNER_NAME=$(hostname)
 fi
 
- ./config.sh --url https://github.com/tecgovtnz --token $TOKEN --runasservice --name $RUNNER_NAME --work _work --runnergroup $ENVIRONMENT --labels $ENVIRONMENT $HOSTNAME
+ ./config.sh --url https://github.com/tecgovtnz --token $TOKEN --runasservice --name $RUNNER_NAME --work _work --runnergroup $ENVIRONMENT --labels $ENVIRONMENT, $HOSTNAME
 # install as a service account
 
 


### PR DESCRIPTION
Adds comma separation as required for multiple labels

https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-labels-with-self-hosted-runners#programmatically-assign-labels