### PR TITLE
Runner pool typo fix

### DIFF
--- a/ansible-utils/ubuntu-gh-runner.sh
+++ b/ansible-utils/ubuntu-gh-runner.sh
@@ -43,7 +43,7 @@ elif [[ "$ENVIRONMENT" == "prod-platform" ]]; then
 elif [[ "$ENVIRONMENT" == "prod-testing" ]]; then
     RUNNER_NAME=$(hostname)-testing
 elif [[ "$ENVIRONMENT" == "prod-platform-testing" ]]; then
-    RUNNER_NAME=$(hostname)platform-testing
+    RUNNER_NAME=$(hostname)-platform-testing
 else
     RUNNER_NAME=$(hostname)
 fi


### PR DESCRIPTION
Fixes a typo causing the prod-testing-platform runners attempting to register with the wrong pool name.

https://app.terraform.io/app/tecgovtnz/workspaces/layer-1/runs/run-bV8gNTfgRR5hMZ6N